### PR TITLE
Fixed bug and removed weird workaround

### DIFF
--- a/src/paginate.js
+++ b/src/paginate.js
@@ -74,6 +74,7 @@ export default {
       this.list.currentPage = typeof page == 'number' ? page - 1 : page;
 
       this.setLimitedPages(limit);
+      this.update(this.originalList);
     };
 
     // Another way to navigate pages (Next & Prev)
@@ -83,6 +84,8 @@ export default {
       this.list.currentPage = (this.list.currentPage + 1 < this.list.numberOfPages) ?
         this.list.currentPage + 1 :
         this.list.currentPage;
+
+      this.update(this.originalList);
     };
 
     vm['prev' + utils.capitalize(this.listName) + 'Page'] = () => {
@@ -91,6 +94,8 @@ export default {
       this.list.currentPage = (this.list.currentPage - 1 > 0) ?
         this.list.currentPage - 1 :
         0;
+
+      this.update(this.originalList);
     };
 
     vm['refresh' + utils.capitalize(this.listName) + 'Page'] = () => {

--- a/test/functional/test.js
+++ b/test/functional/test.js
@@ -40,47 +40,54 @@ describe('Vue-Paginate', () => {
     vm.$data.langs.should.eql(['PHP', 'JS']);
 
     vm.changeLangsPage(2);
-    triggerUpdate();
 
     vm.$data.currentLangsPage.should.equal(2);
     vm.$data.langs.should.eql(['Ruby', 'Python']);
   });
 
-  it('refreshes the list', () => {
+  it('refreshes the list', (done) => {
     vm.$data.langsLinks.should.have.length(2);
     vm.$data.fullLangs = ['PHP', 'JS', 'Ruby', 'Python', 'Java', 'Erlang'];
 
     vm.refreshLangsPage();
-    triggerUpdate();
 
-    vm.$data.langsLinks.should.have.length(3);
+    Vue.nextTick(() => {
+      vm.$data.langsLinks.should.have.length(3);
+      done();
+    });
   });
 
-  it('supports next/prev navigation', () => {
+  it('supports next/prev navigation', (done) => {
     vm.$data.currentLangsPage.should.equal(1);
     vm.$data.langs.should.eql(['PHP', 'JS']);
 
     vm.nextLangsPage();
-    triggerUpdate();
 
-    vm.$data.currentLangsPage.should.equal(2);
-    vm.$data.langs.should.eql(['Ruby', 'Python']);
+    Vue.nextTick(() => {
+      vm.$data.currentLangsPage.should.equal(2);
+      vm.$data.langs.should.eql(['Ruby', 'Python']);
 
-    vm.prevLangsPage();
-    triggerUpdate();
+      vm.prevLangsPage();
 
-    vm.$data.currentLangsPage.should.equal(1);
-    vm.$data.langs.should.eql(['PHP', 'JS']);
+      Vue.nextTick(() => {
+        vm.$data.currentLangsPage.should.equal(1);
+        vm.$data.langs.should.eql(['PHP', 'JS']);
+
+        done();
+      });
+    });
   });
 
-  it('checks if there is a need to show the navigation links', () => {
+  it('checks if there is a need to show the navigation links', (done) => {
     vm.$data.hasLangsLinks.should.be.true;
 
     vm.$data.fullLangs = ['PHP', 'JS'];
     vm.refreshLangsPage();
-    triggerUpdate();
 
-    vm.$data.hasLangsLinks.should.be.false;
+    Vue.nextTick(() => {
+      vm.$data.hasLangsLinks.should.be.false;
+      done();
+    });
   });
 
   it('can be applied on multiple lists at the same time', () => {
@@ -178,5 +185,3 @@ describe('Vue-Paginate', () => {
 
   });
 });
-
-var triggerUpdate = () => vm._directives[0].update(vm.$data.fullLangs);


### PR DESCRIPTION
The `update()` function was never being called except in the tests as some kind of strange workaround. That workaround was impossible in actual usage because of other plugins, so I've added the `change()` calls into the plugin.

The `vm.refresh*Page()` function doesn't really do anything now, because it happens automatically. I'd suggest removing it from tests and documentation (or I can do it).