### PR TITLE
Remove unnecesary vue runtime from build - decreases build size by ~85%

### DIFF
--- a/src/components/PaginateLinks.js
+++ b/src/components/PaginateLinks.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import LimitedLinksGenerator from '../util/LimitedLinksGenerator'
 import { LEFT_ARROW, RIGHT_ARROW, ELLIPSES } from '../config/linkTypes'
 import { warn } from '../util/debug'
@@ -83,7 +82,7 @@ export default {
     if (this.stepLinks && !this.stepLinks.prev) {
       warn(`<paginate-links for="${this.for}"> 'step-links' prop doesn't contain 'prev' value.`, this.$parent)
     }
-    Vue.nextTick(() => {
+    this.$nextTick(() => {
       this.updateListOfPages()
     })
   },
@@ -129,7 +128,7 @@ export default {
     }, links)
 
     if (this.classes) {
-      Vue.nextTick(() => {
+      this.$nextTick(() => {
         addAdditionalClasses(el.elm, this.classes)
       })
     }


### PR DESCRIPTION
The dist build includes the entire vue runtime. This was caused by the import of Vue in PaginateLinks Since it was only used for nextTick, we can reference the component instance instead (`this.$nextTick()`)

This decreases build size by ~85%

Note: I'll leave it up to mainter @TahaSh to run build step, commit, and update published version.

Before:

```
vue-paginate.js 192k
vue-paginate.min.js 63k
```

After:

```
vue-paginate.js 17K
vue-paginate.min.js 8.2K
```

