### PR TITLE
Unlock vue version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "vue"
   ],
   "dependencies": {
-    "vue": "2.3.3"
+    "vue": "^2.3.3"
   },
   "devDependencies": {
     "babel-core": "^6.21.0",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
     "slice",
     "vue"
   ],
-  "dependencies": {
-    "vue": "^2.3.3"
-  },
   "devDependencies": {
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",


### PR DESCRIPTION
The locking of Vue version to 2.3.3 in package.json results in conflicting Vue errors when used in a project with higher Vue version.