### PR TITLE
Fix paginate links on IE9 and above

### DIFF
--- a/src/components/PaginateLinks.js
+++ b/src/components/PaginateLinks.js
@@ -323,7 +323,7 @@ function addAdditionalClasses (linksContainer, classes) {
         linksContainer.classList.add(selectorValue)
       }
     }
-    linksContainer.querySelectorAll(selector).forEach(node => {
+    Array.prototype.slice.call(linksContainer.querySelectorAll(selector), 0).forEach(node => {
       const selectorValue = classes[selector]
       if (Array.isArray(selectorValue)) {
         selectorValue.forEach(c => node.classList.add(c))


### PR DESCRIPTION
Apparently, IE9 and above supports Array.forEach but not for NodeList, which querySelector returns.