### PR TITLE
Prevent negative value for currentPage

### DIFF
--- a/dist/vue-paginate.js
+++ b/dist/vue-paginate.js
@@ -112,7 +112,10 @@
       this.paginateList()
     },
     watch: {
-      currentPage: function currentPage () {
+      currentPage: function currentPage (value) {
+        if(value < 0) {
+          this.currentPage = 0;
+        }
         this.paginateList()
       },
       list: function list () {

--- a/src/components/Paginate.js
+++ b/src/components/Paginate.js
@@ -72,7 +72,6 @@ export default {
       if(value < 0) {
         this.currentPage = 0;
       }
-      
       this.paginateList()
     },
     list () {

--- a/src/components/Paginate.js
+++ b/src/components/Paginate.js
@@ -68,7 +68,11 @@ export default {
     this.paginateList()
   },
   watch: {
-    currentPage () {
+    currentPage (value) {
+      if(value < 0) {
+        this.currentPage = 0;
+      }
+      
       this.paginateList()
     },
     list () {


### PR DESCRIPTION
When given an empty list, the value of currentPage becomes -1.

Even when you then update the empty list with an item, the items still won't show up.

This pull request ensures there can never be a negative value for the currentPage and it will always have an minimum value of 0.

Fixes: #94 