### PR TITLE
support for later loading component

### DIFF
--- a/dist/vue-paginate.js
+++ b/dist/vue-paginate.js
@@ -116,7 +116,7 @@
         this.paginateList()
       },
       list: function list () {
-        if (this.currentPage >= this.lastPage) {
+        if (this.currentPage >= this.lastPage && this.currentPage!==0) {
           this.currentPage = this.lastPage - 1
         }
         this.paginateList()

--- a/src/components/Paginate.js
+++ b/src/components/Paginate.js
@@ -72,7 +72,7 @@ export default {
       this.paginateList()
     },
     list () {
-      if (this.currentPage >= this.lastPage) {
+      if (this.currentPage >= this.lastPage && this.currentPage!==0) {
         this.currentPage = this.lastPage - 1
       }
       this.paginateList()


### PR DESCRIPTION
I was having issues using this with server side pagination since my data was not loading all at once. The main issue I solved here is that the initial load does not go to page -1 rif it has not loaded yet, this enables it to actually load the first page when the data comes in. Before my change it would not load the first page since the watcher `list` would set the page at -1 and even when the data cam in it would not change properly.